### PR TITLE
Providing data, support for entries and refresh, test coverage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "test"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#0.5.5"
+    "polymer": "Polymer/polymer#0.5.5",
+    "underscore": "~1.8.2"
   },
   "devDependencies": {
     "web-component-tester": "~3.1.3"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jshint-stylish": "~1.0.2",
     "run-sequence": "~1.1.0",
     "vinyl-transform": "1.0.0",
-    "web-component-tester": "~2.2.5"
+    "web-component-tester": "~2.2.5",
+    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   }
 }

--- a/rise-rss.html
+++ b/rise-rss.html
@@ -4,10 +4,12 @@
 
 <script src="modules.js"></script>
 
+<script src="../underscore/underscore.js"></script>
+
 <polymer-element name="rise-rss" attributes="url entries refresh">
 
   <script>
-    /* global Polymer, gadgets, RiseVision */
+    /* global Polymer, gadgets, RiseVision, _ */
     /*jshint newcap: false */
 
     (function() {
@@ -54,40 +56,98 @@
          */
         refresh: 0,
 
-        /************************************** INITIALIZATION **************************************/
-
         /**
          * Polymer has finished its initialization. This is the entry point.
          */
         ready: function() {
 
-
         },
 
-        /****************************************** COMMON ******************************************/
+        _prepareResponse: function(feed) {
+          var response = {},
+            limit;
 
-        /**
-         * Performs a request using gadgets.io.makeRequest.
-         */
-        go: function() {
-          // TODO: below is proof of concept using makeRequest and feedme.js. Further commits will refactor go()
-          var params = {};
+          response.feed = feed;
+
+          this.entries = parseInt(this.entries, 10);
+
+          // limit the entries to provide in response
+          if (!isNaN(this.entries) && this.entries > 0) {
+            // ensure feed.items exists
+            if (feed.items && feed.items.length) {
+              // determine value to use for how many items to limit to
+              limit = (feed.items.length >= this.entries) ? this.entries : feed.items.length;
+
+              // revise to include only required entries
+              response.feed.items = _.first(feed.items, limit);
+            }
+          }
+
+          return response;
+        },
+
+        _parseToJSON: function (xml) {
+          var parser = new RiseVision.ModuleExports.FeedMe(true);
+
+          // pass the XML string from the response
+          parser.write(xml);
+
+          // return the JSON parsed object
+          return parser.done();
+        },
+
+        _startTimer: function() {
+          this.refresh = parseInt(this.refresh, 10);
+
+          if (!isNaN(this.refresh) && this.refresh !== 0) {
+            this.refresh = (this.refresh < 1) ? 1 : this.refresh;
+
+            this.job("refresh", function() {
+              this._makeRequest();
+            }, this.refresh * 60000);
+          }
+        },
+
+        _handleRequestError: function (errors) {
+          errors.forEach(function (error) {
+            console.error("RSS Error, gadgets.io.makeRequest: " + error);
+          });
+
+          this._startTimer();
+          this.fire("rise-rss-error", errors);
+        },
+
+        _handleRequestSuccess: function (xml) {
+          var feedJSON = this._parseToJSON(xml);
+
+          this._startTimer();
+          this.fire("rise-rss-response", this._prepareResponse(feedJSON));
+        },
+
+        _makeRequest: function () {
+          var params = {},
+            self = this;
 
           params[gadgets.io.RequestParameters.CONTENT_TYPE] = gadgets.io.ContentType.TEXT;
 
-          gadgets.io.makeRequest(this.url, function(feed) {
-            var parser = new RiseVision.ModuleExports.FeedMe(true),
-              feedJSON;
-
-            // pass the XML string from the response
-            parser.write(feed.text);
-
-            // store the JSON parsed object of the feed
-            feedJSON = parser.done();
-
-            console.dir(feedJSON);
+          gadgets.io.makeRequest(this.url, function(response) {
+            if (response.errors.length > 0) {
+              self._handleRequestError(response.errors);
+            }
+            else {
+              self._handleRequestSuccess(response.data);
+            }
 
           }, params);
+        },
+
+        /**
+         * Performs a request to obtain the RSS feed
+         *
+         * @method go
+         */
+        go: function() {
+          this._makeRequest();
         }
 
       });

--- a/test/data/json-atom.js
+++ b/test/data/json-atom.js
@@ -1,0 +1,71 @@
+var jsonAtom = {
+  type: 'atom',
+  title: 'Example Atom',
+  subtitle: 'Example Atom - Test subtitle',
+  updated: '2005-07-31T12:29:29Z',
+  id: 'tag:example.org,2003:3',
+  link: [
+    {
+      rel: 'alternate',
+      type: 'text/html',
+      hreflang: 'en',
+      href: 'http://example.org/'
+    },
+    {
+      rel: 'self',
+      type: 'application/atom+xml',
+      href: 'http://example.org/feed.atom'
+    }
+  ],
+  rights: 'Copyright (c) 2003, Example',
+  generator: {
+    uri: 'http://www.example.com/',
+    version: '1.0',
+    text: 'Example Toolkit'
+  },
+  items: [
+    {
+      title: 'Atom RSS - Entry 1 title',
+      link: [
+        {
+          rel: 'alternate',
+          type: 'text/html',
+          href: 'http://example.org/2005/04/02/atom'
+        },
+        {
+          rel: 'enclosure',
+          type: 'audio/mpeg',
+          length: '1337',
+          href: 'http://example.org/audio/ph34r_my_podcast.mp3'
+        }
+      ],
+      id: 'tag:example.org,2003:3.2397',
+      updated: '2005-07-31T12:29:29Z',
+      published: '2003-12-13T08:29:29-04:00',
+      author: {
+        name: 'Stuart Lees',
+        uri: 'http://example.org/',
+        email: 'f8dy@example.com'
+      },
+      contributor: [
+        {
+          name: 'Rise Vision'
+        },
+        {
+          name: "Stuart Lees"
+        }
+      ],
+      content: {
+        type: 'xhtml',
+        'xml:lang': 'en',
+        'xml:base': 'http://example.org/',
+        div: {
+          xmlns: 'http://www.w3.org/1999/xhtml',
+          p: {
+            i: 'Atom RSS Item 1 Content'
+          }
+        }
+      }
+    }
+  ]
+};

--- a/test/data/json-rss.js
+++ b/test/data/json-rss.js
@@ -1,0 +1,43 @@
+var jsonRSS = {
+  type: 'rss 2.0',
+  title: 'Example RSS 2.0',
+  link: 'http://www.example.org',
+  description: 'Example RSS 2.0 -  Test description',
+  language: 'en-us',
+  pubdate: 'Tue, 10 Jun 2003 04:00:00 GMT',
+  lastbuilddate: 'Tue, 10 Jun 2003 09:41:01 GMT',
+  docs: 'http://example.com/rss',
+  generator: 'Weblog Editor 2.0',
+  managingeditor: 'editor@example.com',
+  webmaster: 'webmaster@example.com',
+  items:  [
+    {
+      title: 'RSS 2.0 - Entry 1 title',
+      link: 'http://example.com/test.php',
+      description: 'Item 1 - Sample description',
+      pubdate: 'Tue, 03 Jun 2003 09:39:21 GMT',
+      guid: 'http://example.com/rss2.html#example1'
+    },
+    {
+      title: 'RSS 2.0 - Entry 2 title',
+      link: 'http://example.com/test.php',
+      description: 'Item 2 - Sample description',
+      pubdate: 'Fri, 30 May 2003 11:06:42 GMT',
+      guid: 'http://example.com/rss2.html#example2'
+    },
+    {
+      title: 'RSS 2.0 - Entry 3 title',
+      link: 'http://example.com/test.php',
+      description: 'Item 3 - Sample description',
+      pubdate: 'Tue, 27 May 2003 08:37:32 GMT',
+      guid: 'http://example.com/rss2.html#example3'
+    },
+    {
+      title: 'RSS 2.0 - Entry 4 title',
+      link: 'http://example.com/test.php',
+      description: 'Item 4 - Sample description',
+      pubdate: 'Tue, 20 May 2003 08:56:02 GMT',
+      guid: 'http://example.com/rss2.html#example4'
+    }
+  ]
+};

--- a/test/data/xml-atom.js
+++ b/test/data/xml-atom.js
@@ -1,0 +1,35 @@
+var xmlAtom = '<?xml version="1.0" encoding="utf-8"?>' +
+    '<feed xmlns="http://www.w3.org/2005/Atom">' +
+      '<title type="text">Example Atom</title>' +
+      '<subtitle type="html">Example Atom - Test subtitle</subtitle>' +
+      '<updated>2005-07-31T12:29:29Z</updated>' +
+      '<id>tag:example.org,2003:3</id>' +
+      '<link rel="alternate" type="text/html" hreflang="en" href="http://example.org/"/>' +
+      '<link rel="self" type="application/atom+xml" href="http://example.org/feed.atom"/>' +
+      '<rights>Copyright (c) 2003, Example</rights>' +
+      '<generator uri="http://www.example.com/" version="1.0">Example Toolkit</generator>' +
+      '<entry>' +
+        '<title>Atom RSS - Entry 1 title</title>' +
+        '<link rel="alternate" type="text/html" href="http://example.org/2005/04/02/atom"/>' +
+        '<link rel="enclosure" type="audio/mpeg" length="1337" href="http://example.org/audio/ph34r_my_podcast.mp3"/>' +
+        '<id>tag:example.org,2003:3.2397</id>' +
+        '<updated>2005-07-31T12:29:29Z</updated>' +
+        '<published>2003-12-13T08:29:29-04:00</published>' +
+        '<author>' +
+          '<name>Stuart Lees</name>' +
+          '<uri>http://example.org/</uri>' +
+          '<email>f8dy@example.com</email>' +
+        '</author>' +
+        '<contributor>' +
+          '<name>Rise Vision</name>' +
+        '</contributor>' +
+        '<contributor>' +
+          '<name>Stuart Lees</name>' +
+        '</contributor>' +
+        '<content type="xhtml" xml:lang="en" xml:base="http://example.org/">' +
+          '<div xmlns="http://www.w3.org/1999/xhtml">' +
+            '<p><i>Atom RSS Item 1 Content</i></p>' +
+          '</div>' +
+        '</content>' +
+      '</entry>' +
+    '</feed>';

--- a/test/data/xml-rss.js
+++ b/test/data/xml-rss.js
@@ -1,0 +1,43 @@
+var xmlRSS = '<?xml version="1.0"?>' +
+  '<rss version="2.0">' +
+  '<channel>' +
+  '<title>Example RSS 2.0</title>' +
+  '<link>http://www.example.org</link>' +
+  '<description>Example RSS 2.0 -  Test description</description>' +
+  '<language>en-us</language>' +
+  '<pubDate>Tue, 10 Jun 2003 04:00:00 GMT</pubDate>' +
+  '<lastBuildDate>Tue, 10 Jun 2003 09:41:01 GMT</lastBuildDate>' +
+  '<docs>http://example.com/rss</docs>' +
+  '<generator>Weblog Editor 2.0</generator>' +
+  '<managingEditor>editor@example.com</managingEditor>' +
+  '<webMaster>webmaster@example.com</webMaster>' +
+  '<item>' +
+  '<title>RSS 2.0 - Entry 1 title</title>' +
+  '<link>http://example.com/test.php</link>' +
+  '<description>Item 1 - Sample description</description>' +
+  '<pubDate>Tue, 03 Jun 2003 09:39:21 GMT</pubDate>' +
+  '<guid>http://example.com/rss2.html#example1</guid>' +
+  '</item>' +
+  '<item>' +
+  '<title>RSS 2.0 - Entry 2 title</title>' +
+  '<link>http://example.com/test.php</link>' +
+  '<description>Item 2 - Sample description</description>' +
+  '<pubDate>Fri, 30 May 2003 11:06:42 GMT</pubDate>' +
+  '<guid>http://example.com/rss2.html#example2</guid>' +
+  '</item>' +
+  '<item>' +
+  '<title>RSS 2.0 - Entry 3 title</title>' +
+  '<link>http://example.com/test.php</link>' +
+  '<description>Item 3 - Sample description</description>' +
+  '<pubDate>Tue, 27 May 2003 08:37:32 GMT</pubDate>' +
+  '<guid>http://example.com/rss2.html#example3</guid>' +
+  '</item>' +
+  '<item>' +
+  '<title>RSS 2.0 - Entry 4 title</title>' +
+  '<link>http://example.com/test.php</link>' +
+  '<description>Item 4 - Sample description</description>' +
+  '<pubDate>Tue, 20 May 2003 08:56:02 GMT</pubDate>' +
+  '<guid>http://example.com/rss2.html#example4</guid>' +
+  '</item>' +
+  '</channel>' +
+  '</rss>';

--- a/test/mocks/makeRequest.js
+++ b/test/mocks/makeRequest.js
@@ -1,0 +1,17 @@
+var xml;
+
+(function (window, gadgets) {
+  "use strict";
+
+  gadgets.io.makeRequest = function (url, callback) {
+    var response = {
+      data: window.xml,
+      errors: [],
+      rc: 200,
+      text: window.xml
+    };
+
+    callback.call(null, response);
+  }
+
+})(window, gadgets);

--- a/test/rise-rss-integration.html
+++ b/test/rise-rss-integration.html
@@ -12,34 +12,114 @@
 </head>
 <body>
 
-<!-- TODO: test instances -->
+<rise-rss id="request" url="http://feed.xml"></rise-rss>
+
+<script src="data/xml-rss.js"></script>
+<script src="data/json-rss.js"></script>
+<script src="data/xml-atom.js"></script>
+<script src="data/json-atom.js"></script>
+<script src="../node_modules/widget-tester/mocks/gadgets.io-mock.js"></script>
+<script src="mocks/makeRequest.js"></script>
 
 <script>
   suite("rise-rss", function() {
-    var xhr, clock, requests;
+    var clock, responded, listener,
+      rssRequest = document.querySelector("#request");
 
     // Runs for every suite.
     suiteSetup(function() {
-      xhr = sinon.useFakeXMLHttpRequest();
-
-      xhr.onCreate = function (xhr) {
-        requests.push(xhr);
-      };
-
       clock = sinon.useFakeTimers();
     });
 
     suiteTeardown(function() {
-      xhr.restore();
       clock.restore();
     });
 
     // Runs for every test.
     setup(function() {
-      requests = [];
+      xml = xmlRSS; // default
+      responded = false;
     });
 
-    // TODO: test suites
+    suite("response object", function() {
+
+      test("should receive a JavaScript object representation of an RSS 2.0 feed", function(done) {
+        listener = function(response) {
+          responded = true;
+
+          assert.property(response.detail, "feed", "feed property exists");
+          assert.isObject(response.detail.feed, "feed property is an object");
+          assert.deepEqual(response.detail.feed, jsonRSS, "feed property value equals RSS response object");
+
+          rssRequest.removeEventListener("rise-rss-response", listener);
+        };
+
+        rssRequest.addEventListener("rise-rss-response", listener);
+        rssRequest.go();
+
+        assert.isTrue(responded);
+        done();
+      });
+
+      test("should receive a JavaScript object representation of an Atom feed", function(done) {
+        // use an Atom feed in this test
+        xml = xmlAtom;
+
+        listener = function(response) {
+          responded = true;
+
+          assert.property(response.detail, "feed", "feed property exists");
+          assert.isObject(response.detail.feed, "feed property is an object");
+          assert.deepEqual(response.detail.feed, jsonAtom, "feed property value equals Atom response object");
+
+          rssRequest.removeEventListener("rise-rss-response", listener);
+        };
+
+        rssRequest.addEventListener("rise-rss-response", listener);
+        rssRequest.go();
+
+        assert.isTrue(responded);
+        done();
+      });
+
+    });
+
+    suite("entries", function() {
+
+      test("should return all entries in feed", function(done) {
+        listener = function(response) {
+          responded = true;
+
+          assert.equal(response.detail.feed.items.length, jsonRSS.items.length);
+
+          rssRequest.removeEventListener("rise-rss-response", listener);
+        };
+
+        rssRequest.addEventListener("rise-rss-response", listener);
+        rssRequest.go();
+
+        assert.isTrue(responded);
+        done();
+      });
+
+      test("should limit number of entries in feed to 2", function(done) {
+        listener = function(response) {
+          responded = true;
+
+          assert.equal(response.detail.feed.items.length, 2);
+
+          rssRequest.removeEventListener("rise-rss-response", listener);
+        };
+
+        rssRequest.entries = 2;
+        rssRequest.addEventListener("rise-rss-response", listener);
+        rssRequest.go();
+
+        assert.isTrue(responded);
+        done();
+      });
+
+    });
 
 
   });

--- a/test/rise-rss-unit.html
+++ b/test/rise-rss-unit.html
@@ -12,11 +12,17 @@
 </head>
 <body>
 
-<!-- TODO: test instances -->
+<rise-rss id="request" url="http://feed.xml"></rise-rss>
+
+<script src="data/xml-rss.js"></script>
+<script src="data/json-rss.js"></script>
+<script src="data/xml-atom.js"></script>
+<script src="data/json-atom.js"></script>
 
 <script>
   suite("rise-rss", function() {
-    var clock;
+    var clock, responded, listener,
+      rssRequest = document.querySelector("#request");
 
     suiteSetup(function() {
       clock = sinon.useFakeTimers();
@@ -27,11 +33,128 @@
     });
 
     setup(function() {
+      responded = false;
+    });
+
+    suite("_handleRequestError", function() {
+      test("should fire rise-rss-error if there is a problem with the gadgets.io.makeRequest response", function(done) {
+        var errors = [
+            "500 Failed ..."
+          ],
+          listener = function(response) {
+            responded = true;
+
+            assert.isArray(response.detail);
+
+            rssRequest.removeEventListener("rise-storage-error", listener);
+          };
+
+        rssRequest.addEventListener("rise-rss-error", listener);
+        rssRequest._handleRequestError(errors);
+
+        assert.isTrue(responded);
+
+        done();
+      });
+    });
+
+    suite("_handleRequestSuccess", function() {
+      test("should fire rise-rss-response and provide a Javascript object representation of a feed", function(done) {
+
+        listener = function(response) {
+          responded = true;
+
+          assert.isObject(response.detail.feed);
+
+          rssRequest.removeEventListener("rise-storage-response", listener);
+        };
+
+        rssRequest.addEventListener("rise-rss-response", listener);
+        rssRequest._handleRequestSuccess(xmlRSS);
+
+        assert.isTrue(responded);
+        done();
+      });
 
     });
 
-    // TODO: test suites
+    suite("_parseToJSON", function() {
+      var feed;
 
+      test("should return a JavaScript object representation of an RSS 2.0 feed", function() {
+        feed = rssRequest._parseToJSON(xmlRSS);
+
+        assert.isObject(feed);
+        assert.deepEqual(feed, jsonRSS);
+      });
+
+      test("should return a JavaScript object representation of an Atom feed", function() {
+        feed = rssRequest._parseToJSON(xmlAtom);
+
+        assert.isObject(feed);
+        assert.deepEqual(feed, jsonAtom);
+      });
+
+    });
+
+    suite("_prepareResponse", function() {
+      var response;
+
+      test("should return a javascript object with a property named feed, including all entry items", function() {
+        response = rssRequest._prepareResponse(jsonRSS);
+
+        assert.property(response, "feed");
+        assert.isObject(response.feed);
+        assert.equal(response.feed.items.length, jsonRSS.items.length);
+      });
+
+      test("should return only the first 2 entry items of all available entries", function() {
+        rssRequest.entries = 2;
+        response = rssRequest._prepareResponse(jsonRSS);
+
+        assert.equal(response.feed.items.length, 2);
+      });
+
+      test("should return all entry items when entries value higher than feed entries available", function() {
+        rssRequest.entries = 15;
+        response = rssRequest._prepareResponse(jsonRSS);
+
+        assert.equal(response.feed.items.length, jsonRSS.items.length);
+      });
+
+    });
+
+    suite("_startTimer", function() {
+      var timerSpy;
+
+      test("should start a timer", function() {
+        rssRequest.refresh = 10;
+        rssRequest._startTimer();
+        assert.isDefined(rssRequest["___refresh"]);
+      });
+
+      test("should correctly set refresh interval", function() {
+        rssRequest.refresh = 10;
+        rssRequest._startTimer();
+        assert.equal(rssRequest.refresh, 10);
+      });
+
+      test("should enforce a minimum refresh interval", function() {
+        rssRequest.refresh = -1;
+        rssRequest._startTimer();
+        assert.equal(rssRequest.refresh, 1);
+      });
+
+      test("should make a new request for data", function() {
+        timerSpy = sinon.spy(rssRequest, "_makeRequest");
+
+        rssRequest._startTimer();
+
+        clock.tick(60000);
+        assert(timerSpy.calledOnce);
+      });
+
+    });
 
   });
 </script>


### PR DESCRIPTION
- component
  - component now fires "rise-rss-response" passing a full javascript object representation of rss feed
  - component now fires "rise-rss-error" if there was an error returned using `gadgets.io.makeRequest`
  - support added for `entries`, data returned will only include the amount of feed entries specified
  - support added for a `refresh`, "rise-rss-response" will be fired periodically with new request data based on `refresh` value in minutes
- test coverage
  - string based XML files added for both an RSS 2.0 feed and an Atom feed
  - javascript object files added for both an RSS 2.0 feed and an Atom feed, which match their corresponding XML files
  - mock added for `gadgets.io.makeRequest` function
  - unit and integration tests added, full coverage
