### PR TITLE
Adding support for use in Offline Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The RSS Web Component fetches any RSS/Atom feed and returns the data as a Javasc
 
 The specified feed is periodically retrieved if the `refresh` attribute is set, although a minimum refresh time of 1 minute is enforced.
 
-At this time the RSS Web Component is only compatible with the Rise Vision  [Chrome App Player](https://github.com/Rise-Vision/player-chromeapp) or [Viewer](https://github.com/Rise-Vision/viewer).
+At this time the RSS Web Component is only compatible with the Rise Vision  [Chrome App Player](https://github.com/Rise-Vision/player-chromeapp) or [Offline Player](https://github.com/Rise-Vision/offline-player).
 
 ### Entries
 Entries from an RSS feed can optionally be limited to a specific amount.
@@ -39,7 +39,7 @@ Next, construct your HTML page. You should include `webcomponents-lite.min.js` b
       entries="10"
       refresh="5"></rise-rss>
       
-    // Required dependency for use of gadgets.io.makeRequest (proxy server)
+    // NOTE: This dependency is only required when using component within Rise Vision Chrome App Player
     <script src="//rvashow2.appspot.com/gadgets/gadgets.min.js"></script>  
 
     <script>
@@ -131,7 +131,7 @@ The web component returns a Javascript object with the following format (example
 ### Dependencies
 | Description | URL                                    |
 | ------ | ---------------------------------------------- |
-| Required for use of `gadgets.io.makeRequest` (proxy server)   | `//rvashow2.appspot.com/gadgets/gadgets.min.js` |
+| `gadgets.io.makeRequest` (Only required when using component within Rise Vision [Chrome App Player](https://github.com/Rise-Vision/player-chromeapp))  | `//rvashow2.appspot.com/gadgets/gadgets.min.js` |
 
 ## Built With
 - [Polymer](https://www.polymer-project.org/)

--- a/rise-rss.html
+++ b/rise-rss.html
@@ -1,7 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
 
-<script src="//rvashow2.appspot.com/gadgets/gadgets.min.js"></script>
-
 <script src="modules.js"></script>
 
 <script src="../underscore/underscore.js"></script>
@@ -12,6 +10,12 @@
     /* jshint newcap: false */
 
     "use strict";
+
+    var OFFLINE_REGISTRATION = "register.chrome.app.window";
+
+    var OFFLINE_MESSAGE_TYPE = "bypasscors";
+
+    var offlineWindow, offlineOrigin;
 
     Polymer({
       is: "rise-rss",
@@ -90,13 +94,17 @@
       },
 
       _startTimer: function() {
+        var refreshFn = (offlineWindow) ? this._postMessage : this._makeRequest,
+          self = this;
+
         this.refresh = parseInt(this.refresh, 10);
 
         if (!isNaN(this.refresh) && this.refresh !== 0) {
           this.refresh = (this.refresh < 1) ? 1 : this.refresh;
 
-          // calls _makeRequest() after refresh wait duration
-          this.async(this._makeRequest, this.refresh * 60000);
+          this.debounce("refresh", function () {
+            refreshFn.call(self);
+          }, this.refresh * 60000);
         }
       },
 
@@ -112,21 +120,86 @@
         this.fire("rise-rss-response", this._prepareResponse(feedJSON));
       },
 
+      _validateResponse: function(data) {
+        // ensure for actual XML as the data
+        if (typeof data === "string" && data.indexOf('<?xml version="1.0"') !== -1) { // jshint ignore:line
+          this._handleRequestSuccess(data);
+        }
+        else {
+          // the request didn't respond with RSS XML
+          this._handleRequestError("Request response is not XML");
+        }
+      },
+
+      _handleOfflineMessage: function (evt) {
+        if (evt.data === OFFLINE_REGISTRATION) {
+          // store the main window of the offline player
+          offlineWindow = evt.source;
+
+          // store the origin for future "postMessage" calls on the offlineWindow
+          offlineOrigin = evt.origin;
+
+          return;
+        }
+
+        if (offlineWindow) {
+          // check if "error" property was included in response and not empty, handle request error if so
+          if (evt.data.hasOwnProperty("error") && typeof evt.data.error !== "undefined" && evt.data.error !== "") {
+            this._handleRequestError(evt.data.error);
+            return;
+          }
+
+          // check if "response" property included
+          if (evt.data.hasOwnProperty("response")) {
+            this._validateResponse(evt.data.response);
+          }
+        }
+
+      },
+
       _makeRequest: function () {
         var params = {},
           self = this;
 
-        params[gadgets.io.RequestParameters.CONTENT_TYPE] = gadgets.io.ContentType.TEXT;
+        try {
+          params[gadgets.io.RequestParameters.CONTENT_TYPE] = gadgets.io.ContentType.TEXT;
 
-        gadgets.io.makeRequest(this.url, function(response) {
-          if (response.errors.length > 0) {
-            self._handleRequestError(response.errors);
-          }
-          else {
-            self._handleRequestSuccess(response.data);
-          }
+          gadgets.io.makeRequest(this.url, function(response) {
+            if (response.errors.length > 0) {
+              self._handleRequestError(response.errors);
+            }
+            else {
+              self._validateResponse(response.data);
+            }
 
-        }, params);
+          }, params);
+        } catch (e) {
+          console.error("gadgets.io.makeRequest failure", e.message);
+        }
+
+      },
+
+      _postMessage: function () {
+        var message = {
+          type: OFFLINE_MESSAGE_TYPE,
+          url: this.url
+        };
+
+        offlineWindow.postMessage(message, offlineOrigin);
+      },
+
+      /**
+       * Lifecycle callback
+       *
+       * @method ready
+       */
+      ready: function () {
+        var self = this;
+
+        // listen for message event on window which will be heard if running in Offline Player
+        window.addEventListener("message", function (evt) {
+          self._handleOfflineMessage(evt);
+        });
       },
 
       /**
@@ -135,7 +208,12 @@
        * @method go
        */
       go: function() {
-        this._makeRequest();
+        if (offlineWindow) {
+          // running in Offline Player
+          this._postMessage();
+        } else {
+          this._makeRequest();
+        }
       }
 
     });

--- a/test/mocks/makeRequest.js
+++ b/test/mocks/makeRequest.js
@@ -1,7 +1,10 @@
-var xml;
+var xml, gadgets;
 
-(function (window, gadgets) {
+(function (window) {
   "use strict";
+
+  gadgets = {};
+  gadgets.io = {};
 
   gadgets.io.makeRequest = function (url, callback) {
     var response = {
@@ -14,4 +17,4 @@ var xml;
     callback.call(null, response);
   }
 
-})(window, gadgets);
+})(window);

--- a/test/rise-rss-integration.html
+++ b/test/rise-rss-integration.html
@@ -18,8 +18,8 @@
 <script src="data/json-rss.js"></script>
 <script src="data/xml-atom.js"></script>
 <script src="data/json-atom.js"></script>
-<script src="../node_modules/widget-tester/mocks/gadgets.io-mock.js"></script>
 <script src="mocks/makeRequest.js"></script>
+<script src="../node_modules/widget-tester/mocks/gadgets.io-mock.js"></script>
 
 <script>
   suite("rise-rss", function() {

--- a/test/rise-rss-unit.html
+++ b/test/rise-rss-unit.html
@@ -18,6 +18,8 @@
 <script src="data/json-rss.js"></script>
 <script src="data/xml-atom.js"></script>
 <script src="data/json-atom.js"></script>
+<script src="mocks/makeRequest.js"></script>
+<script src="../node_modules/widget-tester/mocks/gadgets.io-mock.js"></script>
 
 <script>
   suite("rise-rss", function() {
@@ -33,6 +35,7 @@
     });
 
     setup(function() {
+      xml = xmlRSS; // default
       responded = false;
     });
 
@@ -146,9 +149,170 @@
 
         clock.tick(60000);
         assert(timerSpy.calledOnce);
+
+        rssRequest._makeRequest.restore();
       });
 
     });
+
+    suite("_validateResponse", function () {
+
+      test("should determine data is not xml and call _handleRequestError", function () {
+        var data = ["This is not XML"],
+          handleErrorSpy = sinon.spy(rssRequest, "_handleRequestError");
+
+        rssRequest._validateResponse(data);
+
+        assert(handleErrorSpy.calledOnce);
+
+        rssRequest._handleRequestError.restore();
+      });
+
+      test("should determine data is XML and call _handleRequestSuccess passing the data", function () {
+        var handleSuccessSpy = sinon.spy(rssRequest, "_handleRequestSuccess");
+
+        rssRequest._validateResponse(xmlRSS);
+
+        assert(handleSuccessSpy.calledWith(xmlRSS));
+
+        rssRequest._handleRequestSuccess.restore();
+      });
+
+    });
+
+    suite("ready", function() {
+      test("should successfully listen for 'message' event", function() {
+        var handleMessageSpy = sinon.spy(rssRequest, "_handleOfflineMessage"),
+          event = new CustomEvent('message');
+
+        window.dispatchEvent(event);
+
+        assert(handleMessageSpy.calledOnce);
+
+      });
+    });
+
+    suite("go", function () {
+
+      test("should call _makeRequest", function () {
+        var makeRequestSpy = sinon.spy(rssRequest, "_makeRequest");
+
+        rssRequest.go();
+
+        assert(makeRequestSpy.calledOnce);
+
+        rssRequest._makeRequest.restore();
+
+      });
+
+      test("should call _postMessage", function () {
+        var postMessageSpy = sinon.spy(rssRequest, "_postMessage"),
+          regEvent = {
+            data: "register.chrome.app.window",
+            origin: "testorigin",
+            source: {
+              postMessage: function () {}
+            }
+          };
+
+        rssRequest._handleOfflineMessage(regEvent);
+        rssRequest.go();
+
+        assert(postMessageSpy.calledOnce);
+
+        rssRequest._postMessage.restore();
+
+      });
+
+    });
+
+    suite("_postMessage", function () {
+
+      test("should have instance of Offline Player main window call 'postMessage' with correct params", function () {
+        var regEvent = {
+          data: "register.chrome.app.window",
+          origin: "testorigin",
+          source: {
+            postMessage: function (){}
+          }
+        },
+          message = {
+            type: "bypasscors",
+            url: rssRequest.url
+          },
+          offlinePostMessage = sinon.spy(regEvent.source, "postMessage");
+
+        rssRequest._handleOfflineMessage(regEvent);
+        rssRequest._postMessage();
+
+        assert(offlinePostMessage.calledWithExactly(message, regEvent.origin));
+
+        regEvent.source.postMessage.restore();
+
+      });
+
+    });
+
+    suite("_handleOfflineMessage", function () {
+
+      var regEvent = {
+        data: "register.chrome.app.window",
+        origin: "testorigin",
+        source: {
+          postMessage: function () {}
+        }
+      }, validateSpy, handleErrorSpy;
+
+      test("should not make any function calls", function () {
+        validateSpy = sinon.spy(rssRequest, "_validateResponse");
+        handleErrorSpy = sinon.spy(rssRequest, "_handleRequestError");
+
+        rssRequest._handleOfflineMessage(regEvent);
+
+        assert.equal(validateSpy.callCount, 0);
+        assert.equal(handleErrorSpy.callCount, 0);
+
+        rssRequest._validateResponse.restore();
+        rssRequest._handleRequestError.restore();
+      });
+
+      test("should call _validateResponse with response value", function () {
+        var messageResponse = {
+          data: {
+            response: "<\?xml version=\"1.0\""
+          }
+        };
+
+        validateSpy = sinon.spy(rssRequest, "_validateResponse");
+
+        rssRequest._handleOfflineMessage(regEvent);
+        rssRequest._handleOfflineMessage(messageResponse);
+
+        assert(validateSpy.calledWith(messageResponse.data.response));
+
+        rssRequest._validateResponse.restore();
+      });
+
+      test("should call _handleRequestError with error value", function () {
+        var errorResponse = {
+          data: {
+            error: "Test error"
+          }
+        };
+
+        handleErrorSpy = sinon.spy(rssRequest, "_handleRequestError");
+
+        rssRequest._handleOfflineMessage(regEvent);
+        rssRequest._handleOfflineMessage(errorResponse);
+
+        assert(handleErrorSpy.calledWith(errorResponse.data.error));
+
+        rssRequest._handleRequestError.restore();
+      });
+
+    });
+
+
 
   });
 </script>


### PR DESCRIPTION
- removed importing `gadgets.min.js`, this should be responsibility of Widget when used in Chrome App Player
- listening to window "message" event on `ready` call of component
- added private static vars for running in offline player
- storing offline player main window and origin for `postMessage` calls
- added `_handleOfflineMessage` function for processing "message" events
- added `_validateResponse` function to ensure for actual string XML as response data
- using `debounce` for "refresh" timer
- `_startTimer` function updated to conditionally call appropriate processing function based on `offlineWindow` value
- unit tests added
- README updated to reflect use in Offline Player
