### PR TITLE
Adding cache support when used in Offline Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Now in your browser, navigate to:
 localhost:8080/components/rise-rss/demo.html
 ``` 
 
-Please note that the demo is purely for demonstrative purposes on how to set up the component. At this time, the standalone demo page will not work as the component requires to be used within Rise Vision [Chrome App Player](https://github.com/Rise-Vision/player-chromeapp) or [Viewer](https://github.com/Rise-Vision/viewer). 
+Please note that the demo is purely for demonstrative purposes on how to set up the component. At this time, the standalone demo page will not work unless used within Rise Vision [Chrome App Player](https://github.com/Rise-Vision/player-chromeapp) or [Offline Player](https://github.com/Rise-Vision/offline-player). 
 
 ### Testing
 You can run the suite of tests either by command terminal or via a local web server using Polyserve. 

--- a/demo.html
+++ b/demo.html
@@ -16,7 +16,7 @@
 
   /*
   NOTE: This is purely for demonstrative purposes on how to set up the component. This standalone demo page will
-  not work as the component requires to be used within Rise Vision Chrome App Player or Viewer.
+  not work as the component requires to be used within Rise Vision Chrome App Player or Offline Player.
    */
 
   function webComponentsReady() {
@@ -25,7 +25,7 @@
     var rss = document.querySelector("#rss");
 
     rss.addEventListener("rise-rss-response", function(e) {
-      console.log(e);
+      console.log(e.detail.feed);
     });
 
     rss.go();

--- a/rise-rss.html
+++ b/rise-rss.html
@@ -15,7 +15,17 @@
 
     var OFFLINE_MESSAGE_TYPE = "bypasscors";
 
+    var LOCAL_STORAGE_NAME = "riserss";
+
     var offlineWindow, offlineOrigin;
+
+    function supportsLocalStorage() {
+      try {
+        return "localStorage" in window && window.localStorage !== null;
+      } catch (e) {
+        return false;
+      }
+    }
 
     Polymer({
       is: "rise-rss",
@@ -64,7 +74,7 @@
         var response = {},
           limit;
 
-        response.feed = feed;
+        response.feed = _.clone(feed);
 
         this.entries = parseInt(this.entries, 10);
 
@@ -114,10 +124,16 @@
       },
 
       _handleRequestSuccess: function (xml) {
-        var feedJSON = this._parseToJSON(xml);
+        var feedJSON = this._parseToJSON(xml),
+          responseData = this._prepareResponse(feedJSON);
+
+        // cache data in local storage if localStorage is supported and component running in Offline Player
+        if (offlineWindow && supportsLocalStorage()) {
+          localStorage.setItem(LOCAL_STORAGE_NAME, JSON.stringify(responseData));
+        }
 
         this._startTimer();
-        this.fire("rise-rss-response", this._prepareResponse(feedJSON));
+        this.fire("rise-rss-response", responseData);
       },
 
       _validateResponse: function(data) {
@@ -129,6 +145,25 @@
           // the request didn't respond with RSS XML
           this._handleRequestError("Request response is not XML");
         }
+      },
+
+      _handleOfflineError: function (error) {
+        var cachedData;
+
+        if (supportsLocalStorage()) {
+          // retrieve any rss data cached and parse back to an object
+          cachedData = JSON.parse(localStorage.getItem(LOCAL_STORAGE_NAME));
+
+          if (cachedData) {
+            // start refresh timer and fire the event using the cached data
+            this._startTimer();
+            this.fire("rise-rss-response", cachedData);
+            return;
+          }
+        }
+
+        // no cached data available, process the error
+        this._handleRequestError(error);
       },
 
       _handleOfflineMessage: function (evt) {
@@ -143,14 +178,15 @@
         }
 
         if (offlineWindow) {
-          // check if "error" property was included in response and not empty, handle request error if so
+          // check if "error" property was included
           if (evt.data.hasOwnProperty("error") && typeof evt.data.error !== "undefined" && evt.data.error !== "") {
-            this._handleRequestError(evt.data.error);
+            this._handleOfflineError(evt.data.error);
             return;
           }
 
           // check if "response" property included
           if (evt.data.hasOwnProperty("response")) {
+            // successful response provided so bypass localStorage retrieval and process the response
             this._validateResponse(evt.data.response);
           }
         }

--- a/test/rise-rss-unit.html
+++ b/test/rise-rss-unit.html
@@ -37,6 +37,7 @@
     setup(function() {
       xml = xmlRSS; // default
       responded = false;
+      localStorage.removeItem("riserss"); // clear localStorage
     });
 
     suite("_handleRequestError", function() {
@@ -192,6 +193,8 @@
       });
     });
 
+    // ********************** Offline Player specific tests  ***********************
+
     suite("go", function () {
 
       test("should call _makeRequest", function () {
@@ -300,19 +303,55 @@
           }
         };
 
-        handleErrorSpy = sinon.spy(rssRequest, "_handleRequestError");
+        handleErrorSpy = sinon.spy(rssRequest, "_handleOfflineError");
 
         rssRequest._handleOfflineMessage(regEvent);
         rssRequest._handleOfflineMessage(errorResponse);
 
         assert(handleErrorSpy.calledWith(errorResponse.data.error));
 
-        rssRequest._handleRequestError.restore();
+        rssRequest._handleOfflineError.restore();
       });
 
     });
 
+    suite("_handleOfflineError", function () {
+      test("should call _handleRequestError with error value", function () {
+        var error = "Test error",
+          handleErrorSpy = sinon.spy(rssRequest, "_handleRequestError");
 
+        // no cached data present in localStorage
+
+        rssRequest._handleOfflineError(error);
+
+        assert(handleErrorSpy.calledOnce);
+
+        rssRequest._handleRequestError.restore();
+      });
+
+      test("should fire rise-rss-response and provide cached data from localStorage", function (done) {
+        var error = "Test error";
+
+        // will result in caching data to localStorage
+        rssRequest._handleRequestSuccess(xmlRSS);
+
+        listener = function(response) {
+          responded = true;
+
+          assert.isObject(response.detail.feed, "Returned an object");
+          assert.deepEqual(response.detail.feed, jsonRSS, "Returned correct data");
+
+          rssRequest.removeEventListener("rise-storage-response", listener);
+        };
+
+        rssRequest.addEventListener("rise-rss-response", listener);
+
+        rssRequest._handleOfflineError(error);
+
+        assert.isTrue(responded);
+        done();
+      });
+    });
 
   });
 </script>


### PR DESCRIPTION
- use of HTML5 `localStorage`
  - new static function `supportsLocalStorage` for ensuring `localStorage` is supported
  - `handleRequestSuccess` updated to call `setItem()` function on `localStorage` with a JSON stringified version of the feed object
  - new function `handleOfflineError` to determine whether cached data can be used and provided or to process the error if not data available
- `prepareResponse` function updated to create a shallow copy of the param value instead of reference it directly
- unit tests added
- `demo.html` updated with minor corrections
- README correction
