### PR TITLE
Adding support for Polymer data binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The web component returns a Javascript object with the following format (example
 | `url` (required) | `<string>` The URL of the RSS/Atom feed.                                          | `''`             |
 | `entries`              | `<number>` The number of entries to return in the data. | `0` (return all entries) |
 | `refresh`              | `<number>` The number of minutes before the data will be refreshed. The minimum refresh time is 1 minute. | `0` (no refresh) |
+| `results`              | `<object>` Result of fetching a feed. | `{}` (notify) |
 
 ### Events
 | Event                   | Description                        |

--- a/rise-rss.html
+++ b/rise-rss.html
@@ -4,6 +4,28 @@
 
 <script src="../underscore/underscore.js"></script>
 
+<!--
+Example usage with Polymer data binding
+<template is="dom-bind">
+  <rise-rss id="rss" url="http://example-feed.xml" entries="10" results="{{result}}"></rise-rss>
+  <div>
+    <h2>{{result.title}}</h2>
+
+    <template is="dom-repeat" items="{{result.items}}" as="entry">
+      <div class="story">
+        <div>
+          <span class="title">{{entry.title}}</span><br>
+          <span>{{entry.pubdate}}</span><br>
+          <p>{{entry.description}}</p>
+        </div>
+      </div>
+    </template>
+  </div>
+
+</template>
+@demo
+-->
+
 <script>
   (function() {
     /* global Polymer, gadgets, RiseVision, _ */
@@ -67,6 +89,15 @@
         refresh: {
           type: Number,
           value: 0
+        },
+
+        /**
+         * Result of RSS feed url
+         */
+        results: {
+          type: Object,
+          value: function() { return {}; },
+          notify: true
         }
       },
 
@@ -119,6 +150,7 @@
       },
 
       _handleRequestError: function (errors) {
+        this.results = {};
         this._startTimer();
         this.fire("rise-rss-error", errors);
       },
@@ -132,6 +164,7 @@
           localStorage.setItem(LOCAL_STORAGE_NAME, JSON.stringify(responseData));
         }
 
+        this.results = responseData.feed;
         this._startTimer();
         this.fire("rise-rss-response", responseData);
       },
@@ -155,6 +188,7 @@
           cachedData = JSON.parse(localStorage.getItem(LOCAL_STORAGE_NAME));
 
           if (cachedData) {
+            this.results = cachedData.feed;
             // start refresh timer and fire the event using the cached data
             this._startTimer();
             this.fire("rise-rss-response", cachedData);

--- a/test/rise-rss-integration.html
+++ b/test/rise-rss-integration.html
@@ -51,6 +51,8 @@
           assert.isObject(response.detail.feed, "feed property is an object");
           assert.deepEqual(response.detail.feed, jsonRSS, "feed property value equals RSS response object");
 
+          assert.deepEqual(rssRequest.results, jsonRSS, "component property 'results' value equals RSS response object");
+
           rssRequest.removeEventListener("rise-rss-response", listener);
         };
 
@@ -71,6 +73,8 @@
           assert.property(response.detail, "feed", "feed property exists");
           assert.isObject(response.detail.feed, "feed property is an object");
           assert.deepEqual(response.detail.feed, jsonAtom, "feed property value equals Atom response object");
+
+          assert.deepEqual(rssRequest.results, jsonAtom, "component property 'results' value equals Atom response object");
 
           rssRequest.removeEventListener("rise-rss-response", listener);
         };

--- a/test/rise-rss-unit.html
+++ b/test/rise-rss-unit.html
@@ -56,6 +56,7 @@
         rssRequest.addEventListener("rise-rss-error", listener);
         rssRequest._handleRequestError(errors);
 
+        assert.deepEqual(rssRequest.results, {});
         assert.isTrue(responded);
 
         done();
@@ -76,6 +77,7 @@
         rssRequest.addEventListener("rise-rss-response", listener);
         rssRequest._handleRequestSuccess(xmlRSS);
 
+        assert.deepEqual(rssRequest.results, jsonRSS);
         assert.isTrue(responded);
         done();
       });


### PR DESCRIPTION
- added `results` attribute with `notify` capability so the value will be surfaced for Polymer data binding in a template
- added example usage in `rise-rss.html` if wanting to use `rise-rss` with Polymer template data binding
- added tests
- updated README
