### PR TITLE
Upgrading demo to display data and reside in <rise-playlist>

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,9 @@
     "underscore": "~1.8.2"
   },
   "devDependencies": {
+    "rise-page": "https://github.com/Rise-Vision/web-component-rise-page.git",
+    "rise-playlist": "https://github.com/Rise-Vision/web-component-rise-playlist.git",
+    "rise-playlist-item": "https://github.com/Rise-Vision/web-component-rise-playlist-item.git",
     "web-component-tester": "~3.1.3"
   }
 }

--- a/demo-content.js
+++ b/demo-content.js
@@ -1,0 +1,95 @@
+var DemoContent = function () {
+  "use strict";
+
+  // provide the playback functions that control this content which rise-playlist will call
+  function _play() {
+    console.log("DemoContent play!");
+    // ...
+  }
+  function _pause() {
+    console.log("DemoContent pause!");
+    // ...
+  }
+  function _stop() {
+    console.log("DemoContent stop!");
+    // ...
+  }
+
+  function _ready() {
+    // construct the "rise-component-ready" event
+    var readyEvent = new CustomEvent("rise-component-ready", {
+      "detail": {
+        "play": _play,
+        "pause": _pause,
+        "stop": _stop,
+        "done": false
+      },
+      "bubbles": true
+    });
+
+    // dispatch the event for rise-playlist to receive
+    document.querySelector("#rss").dispatchEvent(readyEvent);
+  }
+
+  function _build(data) {
+    var itemsContainer = document.querySelector("#rss .items"),
+      fragment = document.createDocumentFragment(),
+      stories = [],
+      story = null;
+
+    // displaying the title of the RSS feed
+    document.querySelector(".rss-container h2").innerHTML = data.title;
+
+    // loop through entries in data and construct markup
+    data.items.forEach(function (entry) {
+      var title, date, description;
+
+      story = document.createElement("div");
+
+      title = document.createElement("h3");
+      title.innerHTML = entry.title;
+
+      date = document.createElement("h5");
+      date.innerHTML = entry.pubdate;
+
+      description = document.createElement("p");
+      description.innerHTML = entry.description;
+
+      story.appendChild(title);
+      story.appendChild(date);
+      story.appendChild(description);
+
+      stories.push(story);
+    });
+
+    stories.forEach(function (story) {
+      fragment.appendChild(story);
+    });
+
+    // add the constructed node to the DOM
+    itemsContainer.appendChild(fragment);
+
+    // content is Ready
+    _ready();
+  }
+
+  function init() {
+    // reference to rise-rss element
+    var rss = document.querySelector("#rss");
+
+    // register for the "rise-rss-response" event that rise-rss fires
+    rss.addEventListener("rise-rss-response", function(e) {
+
+      // build the RSS content with the feed data
+      _build(e.detail.feed);
+
+    });
+
+    // execute making a request for the RSS feed data
+    rss.go();
+  }
+
+  return {
+    "init": init
+  };
+};

--- a/demo.html
+++ b/demo.html
@@ -5,34 +5,66 @@
   <title>rise-rss Demo</title>
 
   <script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
+  <link rel="import" href="../rise-playlist/rise-playlist.html">
+  <link rel="import" href="../rise-playlist-item/rise-playlist-item.html">
   <link rel="import" href="rise-rss.html">
+
+  <style>
+    .rss-container {
+      width: 100%;
+      height: 600px;
+      padding: 10px;
+      position: relative;
+      overflow: auto;
+    }
+  </style>
 
 </head>
 <body unresolved>
 
-<rise-rss id="rss" url="http://rss.cbc.ca/lineup/topstories.xml" entries="10" refresh="2"></rise-rss>
+<rise-playlist>
+
+  <rise-playlist-item>
+    <rise-rss id="rss" url="http://rss.cbc.ca/lineup/topstories.xml" entries="3">
+      <!-- Example HTML structure -->
+      <div class="rss-container">
+        <!-- feed title -->
+        <h2></h2>
+        <!-- feed items -->
+        <div class="items"></div>
+      </div>
+    </rise-rss>
+  </rise-playlist-item>
+
+</rise-playlist>
+
+<!-- Importing javascript which is the logic in building and managing the RSS content -->
+<script type="text/javascript" src="demo-content.js"></script>
 
 <script>
+  /* global DemoContent */
 
-  /*
-  NOTE: This is purely for demonstrative purposes on how to set up the component. This standalone demo page will
-  not work as the component requires to be used within Rise Vision Chrome App Player or Offline Player.
-   */
+  (function () {
+    "use strict";
 
-  function webComponentsReady() {
-    window.removeEventListener("WebComponentsReady", webComponentsReady);
+    /*
+     NOTE: This is purely for demonstrative purposes on how to set up the component. This standalone demo page will
+     not work as the component requires to be used within Rise Vision Chrome App Player or Offline Player.
+     */
 
-    var rss = document.querySelector("#rss");
+    function webComponentsReady() {
+      window.removeEventListener("WebComponentsReady", webComponentsReady);
 
-    rss.addEventListener("rise-rss-response", function(e) {
-      console.log(e.detail.feed);
-    });
+      // new instance of DemoContent object
+      var content = new DemoContent();
 
-    rss.go();
-  }
+      // initialize the content
+      content.init();
+    }
 
-  window.addEventListener("WebComponentsReady", webComponentsReady);
+    window.addEventListener("WebComponentsReady", webComponentsReady);
 
+  })();
 </script>
 
 </body>


### PR DESCRIPTION
- `demo.html`
  - added demo styles
  - refactored to nest `<rise-rss>` within the playlist and playlist item structure
  - added example markup to work with inside `<rise-rss>`
  - importing new `demo-content.js` file and create an instance of `DemoContent`
- `demo-content.js` added to provide an object that contains the necessary logic for obtaining data, displaying data, and adhering to `rise-playlist` requirements
- bower updated to include additional dev dependencies
