### PR TITLE
Fix for early go() call and updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Next, construct your HTML page. You should include `webcomponents-lite.min.js` b
 <html>
   <head>
     <script src="bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
-    <link rel="import" href="bower_components/web-component-rise-rss/rise-rss.html">
+    <link rel="import" href="bower_components/rise-rss/rise-rss.html">
   </head>
   <body>
     <rise-rss
@@ -201,7 +201,9 @@ localhost:8080/components/rise-rss/test/index.html
 ```
 
 ### Deployment
-Once you are satisifed with your changes, deploy the `components` and `rise-rss` folders to your server. You can then use the web component by following the *Usage* instructions.
+Once you are satisifed with your changes, deploy the `bower_components` to your server and also create a `rise-rss` folder within `bower_components` on your server and upload `rise-rss.html` and `modules.js` to it. You can then use the web component by following the *Usage* instructions.
+
+Please note, if you are trying to view the `demo.html` on a remote server you will need to change the `href` values of the imports within the `<head>` of the document to point to your `bower_components` folder on your server. 
 
 ## Submitting Issues
 If you encounter problems or find defects we really want to hear about them. If you could take the time to add them as issues to this Repository it would be most appreciated. When reporting issues, please use the following format where applicable:

--- a/rise-rss.html
+++ b/rise-rss.html
@@ -101,6 +101,8 @@ Example usage with Polymer data binding
         }
       },
 
+      _offlineRequestPending: false,
+
       _prepareResponse: function(feed) {
         var response = {},
           limit;
@@ -208,6 +210,12 @@ Example usage with Polymer data binding
           // store the origin for future "postMessage" calls on the offlineWindow
           offlineOrigin = evt.origin;
 
+          if (this._offlineRequestPending) {
+            // go() was previously called before this registration message was received, execute _postMessage()
+            this._offlineRequestPending = false;
+            this._postMessage();
+          }
+
           return;
         }
 
@@ -230,6 +238,10 @@ Example usage with Polymer data binding
       _makeRequest: function () {
         var params = {},
           self = this;
+
+        if (typeof gadgets === "undefined") {
+          return;
+        }
 
         try {
           params[gadgets.io.RequestParameters.CONTENT_TYPE] = gadgets.io.ContentType.TEXT;
@@ -278,6 +290,13 @@ Example usage with Polymer data binding
        * @method go
        */
       go: function() {
+        if (typeof gadgets === "undefined" && !offlineWindow) {
+          // this scenario can happen if go() is called before Offline Player has dispatched initial "message"
+          this._offlineRequestPending = true;
+
+          return;
+        }
+
         if (offlineWindow) {
           // running in Offline Player
           this._postMessage();

--- a/test/rise-rss-unit.html
+++ b/test/rise-rss-unit.html
@@ -192,6 +192,8 @@
 
         assert(handleMessageSpy.calledOnce);
 
+        rssRequest._handleOfflineMessage.restore();
+
       });
     });
 
@@ -266,7 +268,7 @@
         source: {
           postMessage: function () {}
         }
-      }, validateSpy, handleErrorSpy;
+      }, validateSpy, handleErrorSpy, postMessageSpy;
 
       test("should not make any function calls", function () {
         validateSpy = sinon.spy(rssRequest, "_validateResponse");
@@ -279,6 +281,18 @@
 
         rssRequest._validateResponse.restore();
         rssRequest._handleRequestError.restore();
+      });
+
+      test("should call _postMessage from pending request", function () {
+        postMessageSpy = sinon.spy(rssRequest, "_postMessage");
+
+        rssRequest._offlineRequestPending = true;
+        rssRequest._handleOfflineMessage(regEvent);
+
+        assert(postMessageSpy.calledOnce);
+
+        rssRequest._postMessage.restore();
+        rssRequest._offlineRequestPending = false;
       });
 
       test("should call _validateResponse with response value", function () {


### PR DESCRIPTION
- if `go()` is called with no `gadgets` value and before Offline Player registration "message" is received, setting a pending request flag
- `_handleOfflineMessage` updated to check for pending request on receiving the registration "message"
- unit test added
- README updated to provide clarity and additional instructions for deployment and how it pertains to use of the `demo.html` on a remote server
