### PR TITLE
Catching localStorage errors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-rss",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-rss",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rise Vision web component for retrieving RSS feed data",
   "scripts": {
     "test": "gulp test",

--- a/rise-rss.html
+++ b/rise-rss.html
@@ -127,6 +127,25 @@ can only be used within Rise Vision [Offline Player](https://github.com/Rise-Vis
 
       _offlineRequestPending: false,
 
+      _getCachedData: function () {
+        if (supportsLocalStorage()) {
+          // retrieve cached data and parse back
+          return JSON.parse(localStorage.getItem(LOCAL_STORAGE_NAME));
+        }
+
+        return null;
+      },
+
+      _setCachedData: function (data) {
+        if (supportsLocalStorage()) {
+          try {
+            localStorage.setItem(LOCAL_STORAGE_NAME, JSON.stringify(data));
+          } catch(e) {
+            console.warn(e.message);
+          }
+        }
+      },
+
       _prepareResponse: function(feed) {
         var response = {},
           limit;
@@ -185,9 +204,9 @@ can only be used within Rise Vision [Offline Player](https://github.com/Rise-Vis
         var feedJSON = this._parseToJSON(xml),
           responseData = this._prepareResponse(feedJSON);
 
-        // cache data in local storage if localStorage is supported and component running in Offline Player
-        if (offlineWindow && supportsLocalStorage()) {
-          localStorage.setItem(LOCAL_STORAGE_NAME, JSON.stringify(responseData));
+        if (offlineWindow) {
+          // cache the data if possible
+          this._setCachedData(responseData);
         }
 
         this.results = responseData.feed;
@@ -207,19 +226,14 @@ can only be used within Rise Vision [Offline Player](https://github.com/Rise-Vis
       },
 
       _handleOfflineError: function (error) {
-        var cachedData;
+        var cachedData = this._getCachedData();
 
-        if (supportsLocalStorage()) {
-          // retrieve any rss data cached and parse back to an object
-          cachedData = JSON.parse(localStorage.getItem(LOCAL_STORAGE_NAME));
-
-          if (cachedData) {
-            this.results = cachedData.feed;
-            // start refresh timer and fire the event using the cached data
-            this._startTimer();
-            this.fire("rise-rss-response", cachedData);
-            return;
-          }
+        if (cachedData) {
+          this.results = cachedData.feed;
+          // start refresh timer and fire the event using the cached data
+          this._startTimer();
+          this.fire("rise-rss-response", cachedData);
+          return;
         }
 
         // no cached data available, process the error

--- a/test/rise-rss-unit.html
+++ b/test/rise-rss-unit.html
@@ -20,6 +20,7 @@
 <script src="data/json-atom.js"></script>
 <script src="mocks/makeRequest.js"></script>
 <script src="../node_modules/widget-tester/mocks/gadgets.io-mock.js"></script>
+<script src="../node_modules/widget-tester/mocks/localStorage-mock.js"></script>
 
 <script>
   suite("rise-rss", function() {
@@ -37,7 +38,6 @@
     setup(function() {
       xml = xmlRSS; // default
       responded = false;
-      localStorage.removeItem("riserss"); // clear localStorage
     });
 
     suite("_handleRequestError", function() {
@@ -201,6 +201,10 @@
 
     suite("go", function () {
 
+      teardown(function () {
+        localStorage.removeItem("riserss");
+      });
+
       test("should call _makeRequest", function () {
         var makeRequestSpy = sinon.spy(rssRequest, "_makeRequest");
 
@@ -233,7 +237,62 @@
 
     });
 
+    suite("_setCachedData", function () {
+
+      teardown(function () {
+        window.localStorageError = false;
+        localStorage.removeItem("riserss");
+      });
+
+      test("should catch error thrown by localStorage.setItem and log a warning in console", function () {
+        var warnSpy = sinon.spy(console, "warn");
+
+        // force an error from localStorage.setItem()
+        window.localStorageError = true;
+
+        rssRequest._setCachedData({feed: jsonRSS});
+
+        assert(warnSpy.calledOnce);
+        console.warn.restore();
+      });
+
+      test("should ensure data passed in localStorage.setItem() is stringified", function () {
+        rssRequest._setCachedData({feed:jsonRSS});
+
+        var value = localStorage.getItem("riserss");
+
+        assert.isString(value);
+      });
+
+    });
+
+    suite("_getCachedData", function () {
+      var value;
+
+      teardown(function () {
+        localStorage.removeItem("riserss");
+      });
+
+      test("Should return null when no cached data exists", function () {
+        value = rssRequest._getCachedData();
+
+        assert.isNull(value);
+      });
+
+      test("Should ensure value returned has been parsed as JSON", function () {
+        localStorage.setItem("riserss", JSON.stringify({feed: jsonRSS}));
+
+        value = rssRequest._getCachedData();
+
+        assert.isObject(value);
+      });
+    });
+
     suite("_postMessage", function () {
+
+      teardown(function () {
+        localStorage.removeItem("riserss");
+      });
 
       test("should have instance of Offline Player main window call 'postMessage' with correct params", function () {
         var regEvent = {
@@ -261,6 +320,10 @@
     });
 
     suite("_handleOfflineMessage", function () {
+
+      teardown(function () {
+        localStorage.removeItem("riserss");
+      });
 
       var regEvent = {
         data: "register.chrome.app.window",
@@ -332,6 +395,10 @@
     });
 
     suite("_handleOfflineError", function () {
+      teardown(function () {
+        localStorage.removeItem("riserss");
+      });
+
       test("should call _handleRequestError with error value", function () {
         var error = "Test error",
           handleErrorSpy = sinon.spy(rssRequest, "_handleRequestError");


### PR DESCRIPTION
- Catching and logging a warning in console when `localStorage.setItem()` fails
- Using mock of `localStorage` from widget-tester and revised and added unit tests on code involving `localStorage`
- Version bump
