### PR TITLE
Adding feature for logging usage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-rss",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.0",
     "rise-page": "https://github.com/Rise-Vision/rise-page.git",
     "rise-playlist": "https://github.com/Rise-Vision/rise-playlist.git",
     "rise-playlist-item": "https://github.com/Rise-Vision/rise-playlist-item.git",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,15 +1,16 @@
 (function (console) {
   "use strict";
 
-  var gulp = require("gulp");
-  var bump = require("gulp-bump");
-  var jshint = require("gulp-jshint");
-  var colors = require("colors");
-  var transform = require('vinyl-transform');
-  var runSequence = require("run-sequence");
-  var wct = require("web-component-tester").gulp.init(gulp);
   var bower = require("gulp-bower");
+  var bump = require("gulp-bump");
+  var colors = require("colors");
   var del = require("del");
+  var gulp = require("gulp");
+  var htmlreplace = require("gulp-html-replace");
+  var jshint = require("gulp-jshint");
+  var runSequence = require("run-sequence");
+  var transform = require('vinyl-transform');
+  var wct = require("web-component-tester").gulp.init(gulp);
 
   gulp.task("clean-bower", function(cb){
     del(["./bower_components/**"], cb);
@@ -21,6 +22,19 @@
       .pipe(jshint())
       .pipe(jshint.reporter("jshint-stylish"))
       .pipe(jshint.reporter("fail"));
+  });
+
+  gulp.task("version", function() {
+    var pkg = require("./package.json");
+
+    gulp.src("./rise-rss.html")
+      .pipe(htmlreplace({
+        "version": {
+          src: pkg.version,
+          tpl: "<script>var rssVersion = \"%s\";</script>"
+        }
+      }, {keepBlockTags: true}))
+      .pipe(gulp.dest("./"));
   });
 
   // ***** Primary Tasks ***** //
@@ -41,7 +55,7 @@
     runSequence("test:local", cb);
   });
 
-  gulp.task("build", function (cb) {
+  gulp.task("build", ["version"], function (cb) {
     runSequence("lint", cb);
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-rss",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Rise Vision web component for retrieving RSS feed data",
   "scripts": {
     "test": "gulp test",
@@ -31,6 +31,7 @@
     "gulp": "~3.8.10",
     "gulp-bower": "~0.0.10",
     "gulp-bump": "~0.2.0",
+    "gulp-html-replace": "~1.6.1",
     "gulp-jshint": "~1.10.0",
     "jshint-stylish": "~1.0.2",
     "run-sequence": "~1.1.0",

--- a/rise-rss.html
+++ b/rise-rss.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-ajax/iron-ajax.html">
+<link rel="import" href="../rise-logger/rise-logger.html">
 
 <script src="../underscore/underscore.js"></script>
 
@@ -48,6 +49,7 @@ can only be used within Rise Vision [Offline Player](https://github.com/Rise-Vis
 
 <dom-module id="rise-rss">
   <template>
+    <rise-logger id="logger"></rise-logger>
     <iron-ajax id="feedParserRequest"
                url="{{_feedParserRequestUrl}}"
                handle-as="json"
@@ -57,6 +59,10 @@ can only be used within Rise Vision [Offline Player](https://github.com/Rise-Vis
     </iron-ajax>
   </template>
 </dom-module>
+
+<!-- build:version -->
+<script>var rssVersion = "1.4.0";</script>
+<!-- endbuild -->
 
 <script>
   (function() {
@@ -70,6 +76,8 @@ can only be used within Rise Vision [Offline Player](https://github.com/Rise-Vis
     var OFFLINE_MESSAGE_TYPE = "bypasscors";
 
     var LOCAL_STORAGE_NAME = "riserss";
+
+    var BQ_TABLE_NAME = "component_rss_events";
 
     var offlineWindow, offlineOrigin;
 
@@ -111,6 +119,14 @@ can only be used within Rise Vision [Offline Player](https://github.com/Rise-Vis
         },
 
         /**
+         * The optional usage type for Rise Vision logging purposes. Options are "standalone" or "widget"
+         */
+        usage: {
+          type: String,
+          value: ""
+        },
+
+        /**
          * Result of RSS feed url
          */
         results: {
@@ -141,6 +157,10 @@ can only be used within Rise Vision [Offline Player](https://github.com/Rise-Vis
       _feedParserUrl: "https://feed-parser.risevision.com/",
 
       _feedParserRequestUrl: "",
+
+      _isValidUsage: function(usage) {
+        return usage === "standalone" || usage === "widget";
+      },
 
       _getLocalStorageKey: function () {
         return LOCAL_STORAGE_NAME + "_" + window.btoa(encodeURIComponent( escape( this.url ))) + "_" + this.entries;
@@ -311,7 +331,20 @@ can only be used within Rise Vision [Offline Player](https://github.com/Rise-Vis
       // Element Lifecycle
 
       ready: function () {
-        var self = this;
+        var self = this,
+          params = {
+            event: "ready"
+          };
+
+        // only include usage_type if it's a valid usage value
+        if (this._isValidUsage(this.usage)) {
+          params.usage_type = this.usage;
+        }
+
+        params.version = rssVersion;
+
+        // log usage
+        this.$.logger.log(BQ_TABLE_NAME, params);
 
         // listen for message event on window which will be heard if running in Offline Player
         window.addEventListener("message", function (evt) {

--- a/test/rise-rss-integration.html
+++ b/test/rise-rss-integration.html
@@ -18,9 +18,17 @@
 <script src="mocks/makeRequest.js"></script>
 <script src="../node_modules/widget-tester/mocks/gadgets.io-mock.js"></script>
 <script>
+
+  var rssRequest = document.querySelector("#request"),
+    display = "abc123";
+
+  // mock logger getting display id from Rise Cache
+  sinon.stub(rssRequest.$.logger.$.displayId, "generateRequest", function() {
+    rssRequest.$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+  });
+
   suite("rise-rss", function() {
     var clock, server, listener,
-      rssRequest = document.querySelector("#request"),
       header = { "Content-Type": "application/json" };
 
     // Runs for every suite.

--- a/test/rise-rss-unit.html
+++ b/test/rise-rss-unit.html
@@ -23,10 +23,22 @@
 <script src="../node_modules/widget-tester/mocks/localStorage-mock.js"></script>
 
 <script>
+
+  var rssRequest = document.querySelector("#request"),
+    rssRequest2 = document.querySelector("#request2"),
+    display = "abc123";
+
+  // mock logger getting display id from Rise Cache
+  sinon.stub(rssRequest.$.logger.$.displayId, "generateRequest", function() {
+    rssRequest.$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+  });
+
+  sinon.stub(rssRequest2.$.logger.$.displayId, "generateRequest", function() {
+    rssRequest2.$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+  });
+
   suite("rise-rss", function() {
     var server, clock, responded, listener,
-      rssRequest = document.querySelector("#request"),
-      rssRequest2 = document.querySelector("#request2"),
       header = { "Content-Type": "application/json" };
 
     suiteSetup(function() {
@@ -45,6 +57,19 @@
       server.respondWith("GET", "https://feed-parser.risevision.com/http://feed.xml",
         [200, header, JSON.stringify(jsonRSS)]);
       responded = false;
+    });
+
+    suite("_isValidUsage", function () {
+
+      test("should return true when 'standalone' or 'widget'", function () {
+        assert.isTrue(rssRequest._isValidUsage("widget"));
+        assert.isTrue(rssRequest._isValidUsage("standalone"));
+      });
+
+      test("should return false when invalid", function () {
+        assert.isFalse(rssRequest._isValidUsage("test"));
+      });
+
     });
 
     suite("_handleRequestSuccess", function() {
@@ -146,6 +171,16 @@
     });
 
     suite("ready", function() {
+      var logStub;
+
+      setup(function() {
+        logStub = sinon.stub(rssRequest.$.logger, "log");
+      });
+
+      teardown(function() {
+        logStub.restore();
+      });
+
       test("should successfully listen for 'message' event", function() {
         var handleMessageSpy = sinon.spy(rssRequest, "_handleOfflineMessage"),
           event = new CustomEvent('message');
@@ -156,6 +191,19 @@
 
         rssRequest._handleOfflineMessage.restore();
 
+      });
+
+      test("should log usage", function () {
+        rssRequest.ready();
+        assert.equal(logStub.args[0][0],"component_rss_events");
+        assert.include(JSON.stringify(logStub.args[0][1]),"{\"event\":\"ready\",\"version\":");
+      });
+
+      test("should log usage and include 'usage_type'", function() {
+        rssRequest.usage = "widget";
+        rssRequest.ready();
+        assert.equal(logStub.args[0][0],"component_rss_events");
+        assert.include(JSON.stringify(logStub.args[0][1]),"{\"event\":\"ready\",\"usage_type\":\"widget\",\"version\":");
       });
     });
 


### PR DESCRIPTION
- Using `rise-logger` and logging usage from `ready()` lifecycle.
- Adding `usage` property to allow for a Widget to set a value of "widget"
- Added gulp task "version" when building which injects source for referencing component version (via block tags)
- Logging version
- Revised and added unit tests
